### PR TITLE
Update tracking script to use tag manager

### DIFF
--- a/source/_partials/footer_scripts.html
+++ b/source/_partials/footer_scripts.html
@@ -15,10 +15,4 @@
   </script>
   <script>Munchkin.init('{{ site.marketo_munchkin_id}}');</script>
 
-  <script src="https://pantheon.io/sites/all/themes/zeus/js/pantheon-js-tracking.min.js"></script>
-  <script type="text/javascript">
-  defaults = {'utm_content': window.location.pathname,
-              'utm_source': document.referrer,
-              'utm_campaign': 'docs (organic)'}
-  pantheon_track(defaults)
-  </script>
+  <script type="text/javascript" src="//d2qkfn813cyz6e.cloudfront.net/js/pantheon-js-tracking.min.js?d=e"></script>


### PR DESCRIPTION
From Elizabeth:
"Could you have whoever manages the docs site remove the file "pantheon tracking script.js" (I'm sorry, i can't find the email anywhere!) and replace with
<script type="text/javascript" src="//d2qkfn813cyz6e.cloudfront.net/js/pantheon-js-tracking.min.js?d=e"></script> "
